### PR TITLE
fix: let go of final readline before exiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,14 +132,15 @@ name = "ircat"
 version = "0.1.0"
 dependencies = [
  "bufstream",
+ "libc",
  "rustyline",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 
 [dependencies]
 bufstream = "0.1.4"
+libc = "0.2.141"
 rustyline = "10.0.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                     Ok(0) => {
                         // EOF
                         eprintln!("server stopped responding");
-                        process::exit(1);
+                        // call the input thread to kill this process, so it can release its tty first
+                        unsafe { libc::kill(std::process::id() as i32, libc::SIGTERM) };
                     }
                     Err(e) => {
                         eprintln!("reader failed: {e:?}");


### PR DESCRIPTION
Hi!
So, I got annoyed about something and decided to fix it.
exhibits:
![image](https://user-images.githubusercontent.com/64952797/230591103-9e70c4cd-84ab-4447-9169-487fb1e326f8.png)
![image](https://user-images.githubusercontent.com/64952797/230591120-f63054c3-6e8c-4e63-8452-33a5528d0ecf.png)
here, the server on the other end of the client hung up. This causes ircat to exit. However, it does not correctly reset the cursor of my terminal! 
so you can see that I can no longer *ever* see the last line of my terminal. This is quite annoying, because I usually am typing on that line. Creating new terminals that are on the same machine in cse is a little annoying, so I would prefer to be able to use the same terminal.

The reason this happens is because the network thread exits the whole process while the input thread is blocked on `rustyline::Editor::readline`. This causes readline to leave my terminal in a bad state.
My change now tells the input thread to kill the client, which will then release my terminal correctly before exiting. 

I believe libc works fine on any machine, but admittedly I only tested this on wsl.

~~this took me too long to figure out how to do, because I went down trying to write to my own process's stdin 💀~~

Thanks :)